### PR TITLE
Resolved ECONNREFUSED ERROR

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:16
 # Install basic development tools
 RUN apt update && apt install -y less man-db sudo
 


### PR DESCRIPTION
Closes #1 

[以下記事](https://github.com/nodejs/node/issues/40702)にある、Nodeバージョンのエラーの解決を行った。

Nodeのバージョンを16以下にすることで解決される。